### PR TITLE
Feature/tmuxdir eager mode option

### DIFF
--- a/doc/tmuxdir.txt
+++ b/doc/tmuxdir.txt
@@ -115,9 +115,16 @@ Root markers to identify projects:
 
 >
   let g:tmuxdir_root_markers = ['.git']
-<
 
-tmuxdir.nvim doesn't ship with any default key mappings, but the author's use these mappings:
+
+Eager mode, by default is v:false, in order to stop the recursion for each base dirs
+as soon at a specific depth level (the maximum depth currently is 3) once a root marker is found. Most likely you won't have nested repos, so this will yield faster results. However, if you do have nested repos and want them to be found you want to set this as v:true:
+
+>
+  let g:tmuxdir_eager_mode = v:false
+
+
+tmuxdir.nvim doesn't ship with any default key mappings, but the plugin's author uses these mappings:
 
 >
     nnoremap <silent> <A-m>  :<C-u>Denite -start-filter tmux_session <cr>
@@ -134,6 +141,22 @@ tmuxdir.nvim doesn't ship with any default key mappings, but the author's use th
 RELEASE NOTES						*tmuxdir-release-notes*
 
 2020-03-25 Released v1.0 with documentation.
+2020-08-02 Released g:tmuxdir_eager_mode option set as v:false
+
+On my machine, with g:tmuxdir_eager_mode it resulted in a 5x speed up:
+
+----------------------------------------------------------------------------------------- benchmark: 2 tests -----------------------------------------------------------------------------
+-----------
+Name (time in ms)                        Min                Max               Mean            StdDev             Median               IQR            Outliers       OPS            Rounds
+ Iterations
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-----------
+test_find_projects_v11_not_eager      3.4188 (1.0)       4.3634 (1.0)       3.5153 (1.0)      0.0992 (1.0)       3.4894 (1.0)      0.0593 (1.0)         21;20  284.4703 (1.0)         274
+          1
+test_find_projects_v10_eager         19.3482 (5.66)     20.1614 (4.62)     19.6167 (5.58)     0.1954 (1.97)     19.5694 (5.61)     0.2906 (4.90)         14;0   50.9769 (0.18)         50
+          1
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-----------
 
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:noet:fen:noet:

--- a/plugin/tmuxdir.vim
+++ b/plugin/tmuxdir.vim
@@ -14,6 +14,14 @@ func! TmuxdirBaseDirs()
   endif
 endfunc
 
+func! TmuxdirEagerMode()
+  if exists('g:tmuxdir_eager_mode')
+    return eval('g:tmuxdir_eager_mode')
+  else
+    return v:false
+  endif
+endfunc
+
 if has('nvim')
     finish
 endif

--- a/rplugin/python3/denite/source/tmux_dir.py
+++ b/rplugin/python3/denite/source/tmux_dir.py
@@ -25,6 +25,7 @@ class Source(Base):
             self.tmuxf = TmuxDirFacade(
                 base_dirs=self.vim.eval("TmuxdirBaseDirs()"),
                 root_markers=self.vim.eval("TmuxdirRootMarkers()"),
+                eager_mode=self.vim.eval("TmuxdirEagerMode()"),
             )
         except TmuxDirFacadeException as e:
             util.error(self.vim, str(e))

--- a/rplugin/python3/tmuxdir/dirmngr.py
+++ b/rplugin/python3/tmuxdir/dirmngr.py
@@ -26,12 +26,14 @@ class DirMngr:
         self,
         base_dirs: List[str],
         root_markers: List[str],
+        eager_mode=False,
         cfg_handler: ConfigHandler = None,
     ) -> None:
         """Constructor of DirMngr."""
         self._base_dirs: List[str] = base_dirs
         self._root_markers: List[str] = root_markers
         self._session_dirs: Dict[str, ProjectDir] = {}
+        self._eager_mode = eager_mode
 
         self._IGNORED_DIRS_KEY = "ignored_dirs"
         self._DIRS_KEY = "dirs"
@@ -44,7 +46,7 @@ class DirMngr:
         self._load_dirs()
 
     def find_projects(
-        self, root_dir: str, root_markers: List[str], depth=3, eager=True
+        self, root_dir: str, root_markers: List[str], depth=3, eager=False
     ) -> List[str]:
         """Find project directories given a root_dir and the depth to go through,
         if it's not eager it's going to return early."""
@@ -91,8 +93,7 @@ class DirMngr:
         dirs = self.cfg_handler.load()
         if dirs:
             for key, attr in zip(
-                (self._DIRS_KEY, self._IGNORED_DIRS_KEY,),
-                ("dirs", "ignored_dirs"),
+                (self._DIRS_KEY, self._IGNORED_DIRS_KEY,), ("dirs", "ignored_dirs"),
             ):
                 if dirs.get(key):
                     loaded_dirs = dirs[key]
@@ -121,7 +122,9 @@ class DirMngr:
 
         return [
             self._add(directory)
-            for directory in self.find_projects(input_dir, self._root_markers)
+            for directory in self.find_projects(
+                input_dir, self._root_markers, eager=self._eager_mode
+            )
         ]
 
     def _add(self, input_dir: str) -> str:
@@ -179,7 +182,9 @@ class DirMngr:
             base_dirs.extend(self.dirs.keys())
         dirs: Set[str] = set()
         for input_dir in base_dirs:
-            for walked_dir in self.find_projects(input_dir, self._root_markers):
+            for walked_dir in self.find_projects(
+                input_dir, self._root_markers, eager=self._eager_mode
+            ):
                 if not self.ignored_dirs.get(walked_dir):
                     dirs.add(walked_dir)
         return list(dirs)

--- a/rplugin/python3/tmuxdir/rplugin.py
+++ b/rplugin/python3/tmuxdir/rplugin.py
@@ -21,9 +21,12 @@ class TmuxDirPlugin(object):
         # vim settings
         self.root_markers: List[str] = self.vim.eval("TmuxdirRootMarkers()")
         self.base_dirs: List[str] = self.vim.eval("TmuxdirBaseDirs()")
+        self._eager_mode: bool = self.vim.eval("TmuxdirEagerMode()")
 
         self.dir_mngr = DirMngr(
-            base_dirs=self.base_dirs, root_markers=self.root_markers
+            base_dirs=self.base_dirs,
+            root_markers=self.root_markers,
+            eager_mode=self._eager_mode,
         )
 
         self.tmux_dir = TmuxDirFacade(self.base_dirs, self.root_markers)

--- a/rplugin/python3/tmuxdir/test_dirmngr.py
+++ b/rplugin/python3/tmuxdir/test_dirmngr.py
@@ -78,3 +78,17 @@ class TestDirManager:
         assert dir_mngr.clear_ignored_dirs()
         assert dir_mngr.ignored_dirs == {}
         assert dir_mngr.cfg_handler.load()[dir_mngr._IGNORED_DIRS_KEY] == {}
+
+    @pytest.mark.skipif(
+        not os.path.isdir(os.path.expanduser("~/b/repos")),
+        reason="~/b/repos doesn't exist",
+    )
+    def test_find_projects_v10_eager(self, benchmark, dir_mngr: DirMngr) -> None:
+        benchmark(dir_mngr.find_projects, "~/b/repos", [".git"], 3, True)
+
+    @pytest.mark.skipif(
+        not os.path.isdir(os.path.expanduser("~/b/repos")),
+        reason="~/b/repos doesn't exist",
+    )
+    def test_find_projects_v11_not_eager(self, benchmark, dir_mngr: DirMngr) -> None:
+        benchmark(dir_mngr.find_projects, "~/b/repos", [".git"], 3, False)

--- a/rplugin/python3/tmuxdir/tmuxdir_facade.py
+++ b/rplugin/python3/tmuxdir/tmuxdir_facade.py
@@ -28,11 +28,13 @@ class TmuxDirFacade(TmuxSessionFacade, DirMngr):
         return cls._instance
 
     def __init__(
-        self, base_dirs: List[str], root_markers: List[str] = [".git"]
+        self, base_dirs: List[str], root_markers: List[str] = [".git"], eager_mode=False
     ) -> None:
         """Constructor of TmuxDirFacade."""
         TmuxSessionFacade.__init__(self)
-        DirMngr.__init__(self, base_dirs=base_dirs, root_markers=root_markers)
+        DirMngr.__init__(
+            self, base_dirs=base_dirs, root_markers=root_markers, eager_mode=eager_mode
+        )
 
     def dir_to_session_name(self, dir_path: str) -> str:
         """Convert a directory name to tmux session name."""


### PR DESCRIPTION
This PR adds support for controlling the eager mode behavior when finding the project directories, on `v1.0` release it was eager by default with the maximum depth level as 3. But now, on `v1.1`, it's **not eager** anymore, since it's faster that way, resulted in 5x speedups as tested on my machine on average 3.5ms with 100+ repos being searched. It wasn't too slow before, but now it feels way more instant when using it. 

If you still want the old behavior, and want to search nested repos/projects, then you should set ` let g:tmuxdir_eager_mode = v:false`
