### PR TITLE
Feature/static dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,7 @@ tmuxidir is a tmux session workspace plugin for nvim.
 
 - `:Denite tmux_session` and `:Denite tmux_dir`
 
-![tmuxdir_final2_cropped.gif](https://s5.gifyu.com/images/tmuxdir_final2_cropped.gif)
-
-- `:Denite tmux_dir` (with vim 8+)
-
-![tmuxdir_cropped.gif](https://s5.gifyu.com/images/tmuxdir_cropped.gif)
+![tmuxdir_final2_cropped.gif](https://s4.gifyu.com/images/tmuxdir_final2_cropped.gif)
 
 ## Installation
 

--- a/doc/tmuxdir.txt
+++ b/doc/tmuxdir.txt
@@ -58,8 +58,9 @@ TmuxdirCheck()
 
 
 TmuxdirAdd({arg})
-		Add an {arg} directory to the project list. As long as this folder
-		has a root marker it's going to show up in the project directories.
+		Add an {arg} directory to the project list regardless or root
+		markers or not. It should be used when you don't have root
+		markers or just want to bookmark a directory.
 
 
 TmuxdirClearAdded({arg})

--- a/rplugin/python3/tmuxdir/__init__.py
+++ b/rplugin/python3/tmuxdir/__init__.py
@@ -40,7 +40,7 @@ class TmuxDirRPlugin:
             return []
         try:
             root_dir = expanduser_raise_if_not_dir(args[0])
-            return self._rplugin.tmux_dir.add(root_dir)
+            return [self._rplugin.tmux_dir._add(root_dir)]
         except OSError as e:
             echoerr(self._rplugin.nvim, str(e), self._rplugin.plugin_name)
             return []

--- a/rplugin/python3/tmuxdir/dirmngr.py
+++ b/rplugin/python3/tmuxdir/dirmngr.py
@@ -193,6 +193,6 @@ class DirMngr:
                 if not self.ignored_dirs.get(walked_dir):
                     dirs.add(walked_dir)
         for d in self.dirs:
-            if not self.ignored_dirs.get(walked_dir):
+            if not self.ignored_dirs.get(d):
                 dirs.add(d)
         return list(dirs)

--- a/rplugin/python3/tmuxdir/dirmngr.py
+++ b/rplugin/python3/tmuxdir/dirmngr.py
@@ -185,16 +185,14 @@ class DirMngr:
 
     def list_dirs(self) -> List[str]:
         """Unique list non ignored directories based on root markers."""
-        base_dirs = []
-        if self._base_dirs:
-            base_dirs.extend(self._base_dirs)
-        if self.dirs:
-            base_dirs.extend(self.dirs.keys())
         dirs: Set[str] = set()
-        for input_dir in base_dirs:
+        for d in self._base_dirs:
             for walked_dir in self.find_projects(
-                input_dir, self._root_markers, eager=self._eager_mode
+                d, self._root_markers, eager=self._eager_mode
             ):
                 if not self.ignored_dirs.get(walked_dir):
                     dirs.add(walked_dir)
+        for d in self.dirs:
+            if not self.ignored_dirs.get(walked_dir):
+                dirs.add(d)
         return list(dirs)

--- a/rplugin/python3/tmuxdir/tmux_session_facade.py
+++ b/rplugin/python3/tmuxdir/tmux_session_facade.py
@@ -20,7 +20,7 @@ class TmuxFacadeBinException(TmuxFacadeException):
         super().__init__(msg)
 
 
-class TmuxSession(object):
+class TmuxSession:
 
     """TmuxSession abstraction."""
 
@@ -38,7 +38,7 @@ class TmuxSession(object):
         )
 
 
-class TmuxSessionFacade(object):
+class TmuxSessionFacade:
 
     """Abstraction responsible for switching, listing and creating tmux
     sessions from nvim/vim.

--- a/rplugin/python3/tmuxdir/tmuxdir_facade.py
+++ b/rplugin/python3/tmuxdir/tmuxdir_facade.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from typing import Dict, List
+from typing import List
 from tmuxdir.tmux_session_facade import TmuxSessionFacade, TmuxFacadeException
-from tmuxdir.dirmngr import DirMngr, ProjectDir
-import os
+from tmuxdir.dirmngr import DirMngr
 
 
 class TmuxDirFacadeException(TmuxFacadeException):


### PR DESCRIPTION
`TmuxdirAdd` func now has a new behavior as explained in the docs, if you relied on root markers to add dirs it still work transparently since the new behavior is a superset of it: 

```
TmuxdirAdd({arg})
		Add an {arg} directory to the project list regardless or root
		markers or not. It should be used when you don't have root
		markers or just want to bookmark a directory.
```